### PR TITLE
Updates to work in 2024

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,15 @@
+# macOS Resource Forks
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Outputs/certs
 certs/
 *.pfx
 *.crt
 *.pem
+*.mobileconfig

--- a/build.sh
+++ b/build.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 #
-#update these variables accordingly:
+#update these variables accordingly
 
-udmproaddress=plt-udm
+udmproaddress=192.168.1.1
 country=DE
-organisation='Jollys Network'
+organisation='My Private Network'
 certificatename='HomePod'
 password='password'
 
-scp -r root@${udmproaddress}:/mnt/data/udapi-config/raddb/certs certs
+scp -r root@${udmproaddress}:/data/udapi-config/raddb/certs .
 
 cd certs
 openssl req -subj "/C=${country}/O=${organisation}/CN=${certificatename}" -out myclient.csr -new -newkey rsa:4096 -nodes -keyout myclient.key
 openssl x509 -req -days 365 -in myclient.csr -CA server.pem -CAkey server-key.pem -CAcreateserial -out myclient.crt -sha256
-openssl pkcs12 -passout "pass:${password}" -export -in myclient.crt -inkey myclient.key -out ../"${certificatename} Certificate.pfx"
+openssl pkcs12 -passout "pass:${password}" -export -in myclient.crt -inkey myclient.key -out ../"${certificatename} Certificate.pfx" -legacy # -legacy Required to enter password in Apple Configurator
 cp server.pem ../"Radius Server Certificate.crt"

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ Be aware that this process has to be done every time your server certificate cha
 ```bash
 #!/bin/bash
 #
-#update this variables accordingly
+#update these variables accordingly
 
 udmproaddress=192.168.1.1
 country=DE
@@ -38,12 +38,12 @@ organisation='My Private Network'
 certificatename='HomePod'
 password='password'
 
-scp -r root@${udmproaddress}:/mnt/data/udapi-config/raddb/certs certs
+scp -r root@${udmproaddress}:/data/udapi-config/raddb/certs .
 
 cd certs
 openssl req -subj "/C=${country}/O=${organisation}/CN=${certificatename}" -out myclient.csr -new -newkey rsa:4096 -nodes -keyout myclient.key
 openssl x509 -req -days 365 -in myclient.csr -CA server.pem -CAkey server-key.pem -CAcreateserial -out myclient.crt -sha256
-openssl pkcs12 -passout "pass:${password}" -export -in myclient.crt -inkey myclient.key -out ../"${certificatename} Certificate.pfx"
+openssl pkcs12 -passout "pass:${password}" -export -in myclient.crt -inkey myclient.key -out ../"${certificatename} Certificate.pfx" -legacy # -legacy Required to enter password in Apple Configurator
 cp server.pem ../"Radius Server Certificate.crt"
 ```
 


### PR DESCRIPTION
Made a few changes to make the script work in 2024.

**Main changes**
1. Updated certs directory on UDM Pro
2. Added `-legacy` to pkcs12 cert generation so that the password can be entered in Apple Configurator